### PR TITLE
Tidying up structure

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -25,13 +25,13 @@ jobs:
 
       - name: Generate updated Reference Manual
         run: |
-          pdoc --html --force --output-dir "docs" "MDR"
+          pdoc --html --force --output-dir "docs" "."
 
       - name: Deploy manual to Github Page https://https://qib-sheffield.github.io/MDR_Library/
         uses: s0/git-publish-subdir-action@develop
         env:
           REPO: self
           BRANCH: gh-pages
-          FOLDER: docs/MDR
+          FOLDER: docs/MDR_Library
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MESSAGE: "Reference Manual ${{ steps.date.outputs.date }}"

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 
 ### MDR-Library folder structure
 tests/test_data/*
+data/*
+results/*
 
 ### Python ###
 # Byte-compiled / optimized / DLL files

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,6 @@
+"""
+The MDR library has been developed to simplify use, reduce workflow overhead, and allow generalisability by restructuring the MDR algorithm into an open-source, platform-independent, python based library for model based registration in quantitative renal MRI.
+
+The prototype MDR algorithm (Tagkalakis F, et al. Model-based motion correction outperforms a model-free method in quantitative renal MRI. Abstract-1383, ISMRM 2021) was initially developed using Elastix for co-registration and validated for renal T1-mapping, DTI and DCE against groupwise model-free registration (GMFR). The prototype MDR algorithm has been restructured and extended into the MDR_Library to provide a simple and intuitive application programming interface using ITK-Elastix.
+"""
+__pdoc__ = {"setup": False, "dbdicom": False}

--- a/examples.py
+++ b/examples.py
@@ -1,14 +1,14 @@
 """
-MDR tutorial showing how to motion-correct DICOM T2* data.
+MDR tutorial showing how to motion-correct DICOM T2*, T1, T2 (etc.) data.
 
-The tutorial uses the DICOM example data provided *here*. 
+The tutorial uses the DICOM example data provided [here](https://shorturl.at/rwCUV).
 
-The `dicomdb` package is used to read the DICOM data 
+The `dbdicom` package is used to read the DICOM data 
 and return numpy arrays. 
 
 In order to run the tutorial as is, extract the data in a folder 
-"mydata" in the same directory as this script.
-The results will be saved in a folder "myresults".
+"data" in the same directory as this script.
+The results will be saved in a folder "results".
 
 In order to read and write from other locations, 
 change the path names in the script below.
@@ -40,6 +40,8 @@ import models_signal.T2star_simple as T2star_simple
 # To read and write from/to other locations, change these path names
 data = os.path.join(os.path.dirname(__file__), 'data')
 results = os.path.join(os.path.dirname(__file__), 'results')
+# Check if `data` folder has more files besides README.md
+if len([files for path, subdirs, files in os.walk(data)]) <= 1: raise ValueError("Data folder is empty")
 
 
 def fit_DCE():

--- a/examples.py
+++ b/examples.py
@@ -19,6 +19,7 @@ Then just run this module as a script.
 import os, time
 import numpy as np
 import pandas as pd
+import warnings
 
 from dbdicom import Folder
 
@@ -41,7 +42,7 @@ import models_signal.T2star_simple as T2star_simple
 data = os.path.join(os.path.dirname(__file__), 'data')
 results = os.path.join(os.path.dirname(__file__), 'results')
 # Check if `data` folder has more files besides README.md
-if len([files for path, subdirs, files in os.walk(data)]) <= 1: raise ValueError("Data folder is empty")
+if len([files for path, subdirs, files in os.walk(data)]) <= 1: warnings.warn("Data folder is empty!")
 
 
 def fit_DCE():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 itk-elastix
+matplotlib
 numpy
 pandas
 pdoc3

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,8 @@ if __name__ == '__main__':
         url="https://github.com/QIB-Sheffield/MDR_Library",
         license='Apache Software License (http://www.apache.org/licenses/LICENSE-2.0)',
         python_requires='>=3.6, <4',
-        packages=['MDR'],
-        install_requires=["numpy", "pandas", "SimpleITK", "itk-elastix", "pydicom", "Pillow", "pdoc3", "scipy"],
+        packages=['MDR', 'models_signal'],
+        install_requires=["numpy", "pandas", "SimpleITK", "itk-elastix", "matplotlib", "pydicom", "Pillow", "pdoc3", "scipy", "tqdm"],
         include_package_data=True,
         keywords=['python', "medical imaging", "DICOM", "MRI", "renal", "kidney", "motion correction", "registration"],
         # Classifiers - the purpose is to create a wheel and upload it to PYPI


### PR DESCRIPTION
- Few fixes in `examples.py`
- `data` and `results` folders added to .gitignore
- `setup.py` now contains the models module, which will be part of `pip install mdr-library` in the future
- matplotlib added to `requirements.txt`
- __init__.py file added in order to include the models module in the pdoc3 documentation (and respective github action workflow modified)